### PR TITLE
Fix: show modal on hover instead of using mouseover event

### DIFF
--- a/script.js
+++ b/script.js
@@ -81,26 +81,6 @@ document.addEventListener("submit", function (e) {
   form.reset();
 });
 
-// MOUSEOVER to add modal
-memeSection.addEventListener("mouseover", function (e) {
-  const target = e.target;
-  let modal;
-  if (target.classList.contains("meme-container")) {
-    modal = target.querySelector(".modal");
-  } else return;
-  modal.classList.remove("hidden");
-});
-
-// MOUSEOUT to remove modal
-memeSection.addEventListener("mouseout", function (e) {
-  const target = e.target;
-  let modal;
-  if (target.classList.contains("meme-container")) {
-    modal = target.querySelector(".modal");
-  } else return;
-  modal.classList.add("hidden");
-});
-
 // CLICK to remove meme
 document.addEventListener("click", function (e) {
   const target = e.target;

--- a/style.css
+++ b/style.css
@@ -144,7 +144,7 @@ label,
 .modal {
   /* appearance */
   background-color: var(--black);
-  opacity: 50%;
+  opacity: 0%;
   /* dimensions */
   height: calc(100% - 14px);
   width: 100%;
@@ -154,16 +154,8 @@ label,
   left: 0;
 }
 
-.hidden {
-  visibility: hidden;
-}
-
 .modal:hover {
-  visibility: visible;
-}
-
-.meme-container:hover {
-  visibility: visible;
+  opacity: 50%;
 }
 
 .x-icon-container {


### PR DESCRIPTION
**Fix:** the instability and inconsistency of the modal display behavior

**Previous functionality:**

- Previously, the "remove" modal over each meme was hidden by default.
- It was given 50% opacity.
- The user could display the modal for a given meme by mousing over it (i.e., firing a mouseover event). 
- When the user moved the mouse off the meme (i.e., firing a mouseout event), the modal would be hidden again. 
- The event listeners were placed on the document.

_Problem_: The problem was that too many mouse events were firing and the modal show/hide behavior was inconsistent and buggy.

**New functionality:**
- The functionality is the same, but the behavior is now more stable. 
- Instead of using mouse event listeners to control the visibility of the modal, the :hover pseudo class is implemented on the modals.  

_Note_: I tried to change the visibility CSS property from 'hidden' to 'visible' on hover, but I learned that :hover doesn't work with hidden elements.  Instead, I set opacity to 0% on the modal by default and changed that to 50% when the modal should show.